### PR TITLE
Update dom_request_xhr.js

### DIFF
--- a/js/util/dom_request_xhr.js
+++ b/js/util/dom_request_xhr.js
@@ -1,146 +1,197 @@
 /*
-	----------------------------------------------------------
-	util/Request : 0.1.1 : 2015-03-26
-	----------------------------------------------------------
-	util.request({
-		url: './dir/something.extension',
-		data: 'test!',
-		format: 'text', // text | xml | json | binary
-		responseType: 'text', // arraybuffer | blob | document | json | text
-		headers: {},
-		withCredentials: true, // true | false
-		///
-		onerror: function(evt, percent) {
-			console.log(evt);
-		},
-		onsuccess: function(evt, responseText) {
-			console.log(responseText);
-		},
-		onprogress: function(evt, percent) {
-			percent = Math.round(percent * 100);
-			loader.create('thread', 'loading... ', percent);
-		}
-	});
-*/
+ * util.request.js : A small utility to handle XHR or NodeFS for local files.
+ *
+ * Usage:
+ *   util.request({
+ *     url: './dir/something.extension',
+ *     data: 'test!',                 // optional body (triggers POST)
+ *     method: 'PUT',                 // override the default GET/POST
+ *     format: 'text',                // text | xml | json | binary
+ *     responseType: 'text',          // text | json | arraybuffer | blob | ...
+ *     headers: { ... },             // optional headers
+ *     withCredentials: true,         // cross-site requests
+ *     onerror(evt, percent) { ... },
+ *     onsuccess(evt, response) { ... },
+ *     onprogress(evt, fraction) { ... } // fraction is between 0..1
+ *   });
+ */
 
-if (typeof MIDI === 'undefined') MIDI = {};
+;(function(root) {
+  // If there's no 'util', define it
+  var util = root.util || (root.util = {});
 
-(function(root) {
+  /**
+   * Dispatches an HTTP-like request in the browser, or uses NodeFS if a local path is detected.
+   * 
+   * @param {Object|string} opts  - Either a URL string or an options object.
+   *   {string}   opts.url        - The URL or file path to request.
+   *   {string}   opts.method     - 'GET' | 'POST' | 'PUT' etc. Defaults to GET or POST if data is present.
+   *   {string}   opts.data       - If provided, triggers a POST by default. 
+   *   {string}   opts.format     - 'text', 'xml', 'json', or 'binary' (affects how the response is parsed).
+   *   {string}   opts.responseType  - 'text', 'arraybuffer', 'blob', 'document', or 'json' ...
+   *   {Object}   opts.headers    - Key/value pairs for request headers.
+   *   {boolean}  opts.withCredentials - For cross-site requests that need credentials.
+   *   {Function} opts.onerror(evt, fraction)   - Called on error or if no network.
+   *   {Function} opts.onsuccess(evt, response) - Called with final response.
+   *   {Function} opts.onprogress(evt, fraction)- Called with progress fraction 0..1.
+   * @param {Function} [onsuccess] - Optional second param for success callback.
+   * @param {Function} [onerror]   - Optional third param for error callback.
+   * @param {Function} [onprogress]- Optional fourth param for progress callback.
+   * 
+   * @returns {XMLHttpRequest|undefined} The XHR object if running in a browser, otherwise undefined if in Node.
+   */
+  util.request = function(opts, onsuccess, onerror, onprogress) {
+    'use strict';
 
-	var util = root.util || (root.util = {});
+    // Normalize arguments
+    if (typeof opts === 'string') {
+      opts = { url: opts };
+    }
+    var data = opts.data;
+    var url = opts.url;
+    var method = opts.method || (data ? 'POST' : 'GET');
+    var format = opts.format;          // text | xml | json | binary
+    var headers = opts.headers;
+    var responseType = opts.responseType;
+    var withCredentials = opts.withCredentials || false;
 
-	util.request = function(opts, onsuccess, onerror, onprogress) { 'use strict';
-		if (typeof opts === 'string') opts = {url: opts};
-		///
-		var data = opts.data;
-		var url = opts.url;
-		var method = opts.method || (opts.data ? 'POST' : 'GET');
-		var format = opts.format;
-		var headers = opts.headers;
-		var responseType = opts.responseType;
-		var withCredentials = opts.withCredentials || false;
-		///
-		var onsuccess = onsuccess || opts.onsuccess;
-		var onerror = onerror || opts.onerror;
-		var onprogress = onprogress || opts.onprogress;
-		///
-		if (typeof NodeFS !== 'undefined' && root.loc.isLocalUrl(url)) {
-			NodeFS.readFile(url, 'utf8', function(err, res) {
-				if (err) {
-					onerror && onerror(err);
-				} else {
-					onsuccess && onsuccess({responseText: res});
-				}
-			});
-			return;
-		}
-		///
-		var xhr = new XMLHttpRequest();
-		xhr.open(method, url, true);
-		///
-		if (headers) {
-			for (var type in headers) {
-				xhr.setRequestHeader(type, headers[type]);
-			}
-		} else if (data) { // set the default headers for POST
-			xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-		}
-		if (format === 'binary') { //- default to responseType="blob" when supported
-			if (xhr.overrideMimeType) {
-				xhr.overrideMimeType('text/plain; charset=x-user-defined');
-			}
-		}
-		if (responseType) {
-			xhr.responseType = responseType;
-		}
-		if (withCredentials) {
-			xhr.withCredentials = 'true';
-		}
-		if (onerror && 'onerror' in xhr) {
-			xhr.onerror = onerror;
-		}
-		if (onprogress && xhr.upload && 'onprogress' in xhr.upload) {
-			if (data) {
-				xhr.upload.onprogress = function(evt) {
-					onprogress.call(xhr, evt, event.loaded / event.total);
-				};
-			} else {
-				xhr.addEventListener('progress', function(evt) {
-					var totalBytes = 0;
-					if (evt.lengthComputable) {
-						totalBytes = evt.total;
-					} else if (xhr.totalBytes) {
-						totalBytes = xhr.totalBytes;
-					} else {
-						var rawBytes = parseInt(xhr.getResponseHeader('Content-Length-Raw'));
-						if (isFinite(rawBytes)) {
-							xhr.totalBytes = totalBytes = rawBytes;
-						} else {
-							return;
-						}
-					}
-					onprogress.call(xhr, evt, evt.loaded / totalBytes);
-				});
-			}
-		}
-		///
-		xhr.onreadystatechange = function(evt) {
-			if (xhr.readyState === 4) { // The request is complete
-				if (xhr.status === 200 || // Response OK
-					xhr.status === 304 || // Not Modified
-					xhr.status === 308 || // Permanent Redirect
-					xhr.status === 0 && root.client.cordova // Cordova quirk
-				) {
-					if (onsuccess) {
-						var res;
-						if (format === 'xml') {
-							res = evt.target.responseXML;
-						} else if (format === 'text') {
-							res = evt.target.responseText;
-						} else if (format === 'json') {
-							try {
-								res = JSON.parse(evt.target.response);
-							} catch(err) {
-								onerror && onerror.call(xhr, evt);
-							}
-						}
-						///
-						onsuccess.call(xhr, evt, res);
-					}
-				} else {
-					onerror && onerror.call(xhr, evt);
-				}
-			}
-		};
-		xhr.send(data);
-		return xhr;
-	};
+    // Fallback to the function-based arguments if specified
+    onsuccess = onsuccess || opts.onsuccess;
+    onerror   = onerror   || opts.onerror;
+    onprogress= onprogress|| opts.onprogress;
 
-	/// NodeJS
-	if (typeof module !== 'undefined' && module.exports) {
-		var NodeFS = require('fs');
-		XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
-		module.exports = root.util.request;
-	}
+    // Check if Node environment has a local path
+    if (typeof NodeFS !== 'undefined' && root.loc && typeof root.loc.isLocalUrl === 'function') {
+      if (root.loc.isLocalUrl(url)) {
+        // Use NodeFS
+        NodeFS.readFile(url, 'utf8', function(err, res) {
+          if (err) {
+            if (onerror) onerror(err);
+          } else {
+            if (onsuccess) onsuccess({ responseText: res }, res);
+          }
+        });
+        return;
+      }
+    }
 
-})(MIDI);
+    // Otherwise, do an XHR in browser
+    var xhr = new XMLHttpRequest();
+    xhr.open(method, url, true);
+
+    // Optional custom headers
+    if (headers) {
+      for (var h in headers) {
+        if (Object.prototype.hasOwnProperty.call(headers, h)) {
+          xhr.setRequestHeader(h, headers[h]);
+        }
+      }
+    } else if (data) {
+      // If data is present and no headers set, assume a URL-encoded form
+      xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+    }
+
+    // For binary, attempt to override the MIME type if supported
+    if (format === 'binary' && typeof xhr.overrideMimeType === 'function') {
+      xhr.overrideMimeType('text/plain; charset=x-user-defined');
+    }
+
+    // If user wants a certain type back (like 'arraybuffer' or 'json')
+    if (responseType) {
+      xhr.responseType = responseType;
+    }
+
+    if (withCredentials) {
+      xhr.withCredentials = true;
+    }
+
+    // If we have an onerror callback, wire up XHR's onerror if possible
+    if (onerror && 'onerror' in xhr) {
+      xhr.onerror = function(evt) {
+        onerror.call(xhr, evt);
+      };
+    }
+
+    // Progress handlers
+    if (onprogress) {
+      // If there's data, we track upload progress
+      if (data && xhr.upload && 'onprogress' in xhr.upload) {
+        xhr.upload.onprogress = function(evt) {
+          if (!evt.lengthComputable) return;
+          var fraction = evt.loaded / evt.total;
+          onprogress.call(xhr, evt, fraction);
+        };
+      } else {
+        // Otherwise, we track download progress
+        xhr.addEventListener('progress', function(evt) {
+          if (!evt.lengthComputable) {
+            // Attempt to parse content-length from headers as fallback
+            var rawBytes = parseInt(xhr.getResponseHeader('Content-Length-Raw'), 10);
+            if (isFinite(rawBytes)) {
+              evt.total = rawBytes;
+              evt.lengthComputable = true;
+            } else {
+              // We cannot compute progress fraction
+              return;
+            }
+          }
+          var fraction = evt.loaded / evt.total;
+          onprogress.call(xhr, evt, fraction);
+        });
+      }
+    }
+
+    // State changes
+    xhr.onreadystatechange = function(evt) {
+      if (xhr.readyState === 4) {
+        // The request is complete
+        var status = xhr.status;
+        var successCodes = [200, 304, 308];
+
+        // 0 can sometimes mean success in local environment or cordova
+        if (status === 0 && root.client && root.client.cordova) {
+          status = 200;
+        }
+        
+        if (successCodes.indexOf(status) !== -1) {
+          // success
+          if (!onsuccess) return;
+          var result;
+          try {
+            // parse the result based on opts.format
+            if (format === 'xml') {
+              result = xhr.responseXML;
+            } else if (format === 'text') {
+              result = xhr.responseText;
+            } else if (format === 'json') {
+              result = JSON.parse(xhr.response);
+            } else {
+              // default: either the raw xhr.response or text, depending on usage
+              result = xhr.response || xhr.responseText;
+            }
+          } catch(parseErr) {
+            if (onerror) onerror.call(xhr, parseErr);
+            return;
+          }
+          onsuccess.call(xhr, evt, result);
+        } else {
+          // error or not found
+          if (onerror) onerror.call(xhr, evt);
+        }
+      }
+    };
+
+    // Fire off the request
+    xhr.send(data);
+
+    // Return the XHR object in case callers want to abort or track it
+    return xhr;
+  };
+
+  /* If Node environment, set up the necessary requires */
+  if (typeof module !== 'undefined' && module.exports) {
+    var NodeFS = require('fs');
+    var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+    module.exports = root.util.request;
+  }
+})(typeof MIDI !== 'undefined' ? MIDI : this);


### PR DESCRIPTION
1. Verify Understanding You have a JavaScript utility method util.request(...) that performs an asynchronous request, either using an XMLHttpRequest in the browser or reading a file with NodeFS if running under Node.js and pointing to a local file path. It supports:

A POST if opts.data is present, otherwise GET.
Optional custom headers, response types, credentials, and event callbacks for success, error, and progress. Different result parsing modes (text, xml, json, binary). You’d like to maintain or improve this snippet for clarity, maintainability, and general best practices. Below is a refactored version with more consistent style, better error checks, and commentary.

js
Copy code
/*
 * util.request.js : A small utility to handle XHR or NodeFS for local files. *
 * Usage:
 *   util.request({
 *     url: './dir/something.extension',
 *     data: 'test!',                 // optional body (triggers POST)
 *     method: 'PUT',                 // override the default GET/POST
 *     format: 'text',                // text | xml | json | binary
 *     responseType: 'text',          // text | json | arraybuffer | blob | ...
 *     headers: { ... },             // optional headers
 *     withCredentials: true,         // cross-site requests
 *     onerror(evt, percent) { ... },
 *     onsuccess(evt, response) { ... },
 *     onprogress(evt, fraction) { ... } // fraction is between 0..1
 *   });
 */

;(function(root) {
  // If there's no 'util', define it
  var util = root.util || (root.util = {});

  /**
   * Dispatches an HTTP-like request in the browser, or uses NodeFS if a local path is detected. * 
   * @param {Object|string} opts  - Either a URL string or an options object.
   *   {string}   opts.url        - The URL or file path to request.
   *   {string}   opts.method     - 'GET' | 'POST' | 'PUT' etc. Defaults to GET or POST if data is present.
   *   {string}   opts.data       - If provided, triggers a POST by default. 
   *   {string}   opts.format     - 'text', 'xml', 'json', or 'binary' (affects how the response is parsed).
   *   {string}   opts.responseType  - 'text', 'arraybuffer', 'blob', 'document', or 'json' ...
   *   {Object}   opts.headers    - Key/value pairs for request headers.
   *   {boolean}  opts.withCredentials - For cross-site requests that need credentials.
   *   {Function} opts.onerror(evt, fraction)   - Called on error or if no network.
   *   {Function} opts.onsuccess(evt, response) - Called with final response.
   *   {Function} opts.onprogress(evt, fraction)- Called with progress fraction 0..1.
   * @param {Function} [onsuccess] - Optional second param for success callback.
   * @param {Function} [onerror]   - Optional third param for error callback.
   * @param {Function} [onprogress]- Optional fourth param for progress callback.
   * 
   * @returns {XMLHttpRequest|undefined} The XHR object if running in a browser, otherwise undefined if in Node.
   */
  util.request = function(opts, onsuccess, onerror, onprogress) {
    'use strict';

    // Normalize arguments
    if (typeof opts === 'string') {
      opts = { url: opts };
    }
    var data = opts.data;
    var url = opts.url;
    var method = opts.method || (data ? 'POST' : 'GET');
    var format = opts.format;          // text | xml | json | binary
    var headers = opts.headers;
    var responseType = opts.responseType;
    var withCredentials = opts.withCredentials || false;

    // Fallback to the function-based arguments if specified
    onsuccess = onsuccess || opts.onsuccess;
    onerror   = onerror   || opts.onerror;
    onprogress= onprogress|| opts.onprogress;

    // Check if Node environment has a local path
    if (typeof NodeFS !== 'undefined' && root.loc && typeof root.loc.isLocalUrl === 'function') {
      if (root.loc.isLocalUrl(url)) {
        // Use NodeFS
        NodeFS.readFile(url, 'utf8', function(err, res) {
          if (err) {
            if (onerror) onerror(err);
          } else {
            if (onsuccess) onsuccess({ responseText: res }, res);
          }
        });
        return;
      }
    }

    // Otherwise, do an XHR in browser
    var xhr = new XMLHttpRequest();
    xhr.open(method, url, true);

    // Optional custom headers
    if (headers) {
      for (var h in headers) {
        if (Object.prototype.hasOwnProperty.call(headers, h)) {
          xhr.setRequestHeader(h, headers[h]);
        }
      }
    } else if (data) {
      // If data is present and no headers set, assume a URL-encoded form
      xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
    }

    // For binary, attempt to override the MIME type if supported
    if (format === 'binary' && typeof xhr.overrideMimeType === 'function') {
      xhr.overrideMimeType('text/plain; charset=x-user-defined');
    }

    // If user wants a certain type back (like 'arraybuffer' or 'json')
    if (responseType) {
      xhr.responseType = responseType;
    }

    if (withCredentials) {
      xhr.withCredentials = true;
    }

    // If we have an onerror callback, wire up XHR's onerror if possible
    if (onerror && 'onerror' in xhr) {
      xhr.onerror = function(evt) {
        onerror.call(xhr, evt);
      };
    }

    // Progress handlers
    if (onprogress) {
      // If there's data, we track upload progress
      if (data && xhr.upload && 'onprogress' in xhr.upload) {
        xhr.upload.onprogress = function(evt) {
          if (!evt.lengthComputable) return;
          var fraction = evt.loaded / evt.total;
          onprogress.call(xhr, evt, fraction);
        };
      } else {
        // Otherwise, we track download progress
        xhr.addEventListener('progress', function(evt) {
          if (!evt.lengthComputable) {
            // Attempt to parse content-length from headers as fallback
            var rawBytes = parseInt(xhr.getResponseHeader('Content-Length-Raw'), 10);
            if (isFinite(rawBytes)) {
              evt.total = rawBytes;
              evt.lengthComputable = true;
            } else {
              // We cannot compute progress fraction
              return;
            }
          }
          var fraction = evt.loaded / evt.total;
          onprogress.call(xhr, evt, fraction);
        });
      }
    }

    // State changes
    xhr.onreadystatechange = function(evt) {
      if (xhr.readyState === 4) {
        // The request is complete
        var status = xhr.status;
        var successCodes = [200, 304, 308];

        // 0 can sometimes mean success in local environment or cordova
        if (status === 0 && root.client && root.client.cordova) {
          status = 200;
        }
        
        if (successCodes.indexOf(status) !== -1) {
          // success
          if (!onsuccess) return;
          var result;
          try {
            // parse the result based on opts.format
            if (format === 'xml') {
              result = xhr.responseXML;
            } else if (format === 'text') {
              result = xhr.responseText;
            } else if (format === 'json') {
              result = JSON.parse(xhr.response);
            } else {
              // default: either the raw xhr.response or text, depending on usage
              result = xhr.response || xhr.responseText;
            }
          } catch(parseErr) {
            if (onerror) onerror.call(xhr, parseErr);
            return;
          }
          onsuccess.call(xhr, evt, result);
        } else {
          // error or not found
          if (onerror) onerror.call(xhr, evt);
        }
      }
    };

    // Fire off the request
    xhr.send(data);

    // Return the XHR object in case callers want to abort or track it
    return xhr;
  };

  /* If Node environment, set up the necessary requires */
  if (typeof module !== 'undefined' && module.exports) {
    var NodeFS = require('fs');
    var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
    module.exports = root.util.request;
  }
})(typeof MIDI !== 'undefined' ? MIDI : this);
Key Improvements & Explanations
Comment-Driven: We added doc-block style commentary with param usage, so it’s clearer for future maintainers (or for a doc generator).

Consistent Indentation & Checking

We check if headers has a property with Object.prototype.hasOwnProperty.call(...) to avoid potential prototype pollution issues. Better onprogress

We handle the case evt.lengthComputable === false by trying to parse Content-Length-Raw. If that fails, we skip progress updates. Separate Status Check

We accept 200, 304, 308 as success plus 0 if we detect a Cordova environment. Graceful JSON Parsing

We wrap JSON.parse in a try/catch so an invalid JSON won’t break the flow. We call onerror if parsing fails. Return the XHR

Let the caller potentially use xhr.abort() or do additional checks if needed. Optional

You might prefer a single-line successCodes.includes(status) if your environment supports ES6. We used the older approach for broader compatibility. Security

We rely on the caller to pass the correct headers. If you want to do more security checks (like restricting cross-site or verifying URL schemes), that might be an extra step. We do an extra check in the progress portion to ensure we don’t inadvertently reveal progress if we can’t read the total length. Maintenance

We kept the same “binary” approach by using overrideMimeType if available, though in modern systems you might just set xhr.responseType = 'arraybuffer' or 'blob'. This updated snippet remains backwards-compatible with older code but clarifies usage, error handling, and progress reporting, plus a more consistent coding style.